### PR TITLE
Corrected rawBody

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -17,7 +17,7 @@ export type FunctionRequest = {
   query: { [key: string]: string }
   headers: { [name: string]: string }
   body: any
-  rawbody: any
+  rawBody: any
 }
 
 export type FunctionResponse = {


### PR DESCRIPTION
.rawbody does not exist with functions v2. `.rawBody` is the correct field